### PR TITLE
Bump Go to 1.23 which includes new linter rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     tags:
       - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           version: latest
           args: build --clean
       - name: Run GoReleaser Release
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version: stable
       - name: Run GoReleaser Build
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,7 +10,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up Go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,10 +30,17 @@ linters-settings:
     local-prefixes: github.com/golangci/golangci-lint
   golint:
     min-confidence: 0
-  gomnd:
-    checks: argument,case,condition,return
   govet:
     disable-all: true
+    # Enable analyzers by name.
+    # (in addition to default:
+    #   appends, asmdecl, assign, atomic, bools, buildtag, cgocall, composites, copylocks, defers, directive, errorsas,
+    #   framepointer, httpresponse, ifaceassert, loopclosure, lostcancel, nilfunc, printf, shift, sigchanyzer, slog,
+    #   stdmethods, stringintconv, structtag, testinggoroutine, tests, timeformat, unmarshal, unreachable, unsafeptr,
+    #   unusedresult
+    # ).
+    # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
+    # Default: []
     enable:
       - appends
       - asmdecl
@@ -78,7 +85,7 @@ linters-settings:
   lll:
     line-length: 160
   misspell:
-    locale: UK
+    locale: US, UK
   nolintlint:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
@@ -90,10 +97,12 @@ linters:
     - bodyclose
     - dogsled
     - dupl
-    - exportloopref
+    - copyloopvar
     - errcheck
     - funlen
     - goconst
+    - gosmopolitan
+    - gocritic
     - gocyclo
     - gofmt
     - goimports
@@ -104,6 +113,7 @@ linters:
     - ineffassign
     - lll
     - misspell
+    - mnd
     - nakedret
     - nolintlint
     - rowserrcheck
@@ -119,9 +129,13 @@ linters:
 issues:
   # Exclude configuration for test files
   exclude-rules:
-    - path: (.+)_test.go
+    - path: _test\.go
       linters:
+        - gomnd # magic numbers
+        - govet # we don't care about align and other problems in test files usually.
         - lll # long lines; test strings, bytes etc.
+        - mnd # magic numbers
         - scopelint # using tt var in ranged loop
         - funlen # long functions, common in table-driven tests
-        - govet # fieldalignment on test structs
+        - dupl # duplicate code detection
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 report_sizes: true
 
 before:
@@ -30,14 +31,28 @@ builds:
       - netbsd
       - openbsd
       - windows
+
     goarch:
       - amd64
       - arm
       - arm64
-      - 386
+
     goarm:
       - 6
       - 7
+
+    goamd64:
+      - v2
+      - v3
+
+    ignore:
+      - goos: darwin
+        goarch: arm
+        goarm: 6
+      - goos: darwin
+        goarch: arm
+        goarm: 7
+
 
     mod_timestamp: "{{ .CommitTimestamp }}"
     skip: false

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ deps:
 	@echo ""
 	@echo "***** Installing dependencies for ${TOOL} *****"
 	go clean --cache
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
 
 lint: deps reportdir
 	@echo ""

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jimmystewpot/in-addr
 
-go 1.22.1
+go 1.23
 
 require (
 	github.com/alecthomas/kong v0.9.0


### PR DESCRIPTION
Go version 1.23 has some improved syntax and linting available, this bumps the version for consistency with other projects.